### PR TITLE
Added German localization

### DIFF
--- a/_locales/de/messages.json
+++ b/_locales/de/messages.json
@@ -1,0 +1,14 @@
+{
+  "extensionName": {
+    "message": "Andere Tabs schließen Menüpunkt",
+    "description": "Extension name"
+  },
+  "extensionDescription": {
+    "message": "Fügt einen 'Andere Tabs schließen' Eintrag im Tab-Kontextmenü hinzu",
+    "description": "Extension description"
+  },
+  "menuItemTitle": {
+    "message": "&Andere Tabs schließen",
+    "description": "Context menu item title"
+  }
+}


### PR DESCRIPTION
Thanks for this! :)

I quickly translated this into German.

(The menu access key is `a` to match the language and the default Firefox behaviour.)